### PR TITLE
Update python to actively supported versions & update test dependencies to match

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install test dependencies
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,9 +15,9 @@ jobs:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A helper library in Python for authors of workflows for [Alfred 4 and 5][alfred]
 [![Supported Python Versions][shield-pyversions]][pypi]
 
 <!-- [![Downloads][shield-download]][pypi] -->
-Supports Alfred 4 and Alfred 5 on macOS Catalina or later with Python 3.7+.
+Supports Alfred 4 and Alfred 5 on macOS Catalina or later with Python 3.8+.
 
 Alfred-PyWorkflow is a Python 3 port of the original [Alfred-Workflow][alfred-workflow].
 

--- a/README_PYPI.rst
+++ b/README_PYPI.rst
@@ -1,7 +1,7 @@
 
 A helper library for writing `Alfred 4 and 5`_ workflows.
 
-Supports macOS Catalina and Python 3.7+.
+Supports macOS Catalina and Python 3.8+.
 
 Alfred-Workflow is designed to take the grunt work out of writing a workflow.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,13 +7,6 @@ Contributing
 
 Alfred-Workflow is an open-source project and contributions are welcome.
 
-.. important::
-
-    **Do not submit yet another feature request for Python 3 support**
-
-    I am aware of the existence of Python 3. There will be a rewrite of the library that removes all the crufy and only supports Python 3 when I get around to it.
-
-
 .. _bugs:
 
 Feature requests and bugs

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
-pytest==7.1.3
-pytest-cov==3.0.0
-pytest-localserver==0.7.0
-flake8==5.0.4
-flake8-docstrings==1.6.0
+pytest==8.1.1
+pytest-cov==5.0.0
+pytest-localserver==0.8.1
+flake8==7.0.0
+flake8-docstrings==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,11 @@ classifiers = [
     'Operating System :: MacOS :: MacOS X',
     'Intended Audience :: Developers',
     'Natural Language :: English',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Software Development :: Libraries',
     'Topic :: Software Development :: Libraries :: Application Frameworks',
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,7 @@ in the project root to run the full test suite in place with coverage.
 ```bash
 tox
 ```
-in the project root to build, install and test with Python 3.7.
+in the project root to build, install and test with Python 3.8.
 
 
 Testing a single module with coverage

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ addopts =
     --doctest-modules
 
 [tox]
-envlist=py37,py38,py39, py310
+envlist=py38,py39,py310,py311,py312
 
 [testenv]
 usedevelop = true
@@ -24,13 +24,6 @@ deps =
     coverage
 
 commands = ./run-tests.sh
-
-; [testenv:py26]
-; deps =
-;     {[testenv]deps}
-
-; [pydocstyle]
-; add_ignore = D105,D203,D266,D400,D401,D413
 
 [flake8]
 ignore =


### PR DESCRIPTION
Let me know if want any/only part of these changes:
- updating python to 3.8+ as 3.7 is no longer actively supported
- updating test dependencies to ensure support up to python 3.12
- update GithubActions to use new node20 runners